### PR TITLE
feat(plugin): add disable-job-button:1.v9db_352414f90

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -56,6 +56,7 @@ customizable-header:135.vf8ce4237feb_c
 dark-theme:479.v661b_1b_911c01
 data-tables-api:2.1.6-1
 design-library:307.vecc0205ca_707
+disable-job-button:1.v9db_352414f90
 display-url-api:2.204.vf6fddd8a_8b_e9
 docker-commons:443.v921729d5611d
 durable-task:568.v8fb_5c57e8417


### PR DESCRIPTION
as this button had been removed from core, we need the plugin