### PR TITLE
cleanup(plugins) remove deprecated JaCoCo plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -81,7 +81,6 @@ inline-pipeline:1.0.3
 instance-identity:201.vd2a_b_5a_468a_a_6
 ionicons-api:74.v93d5eb_813d5f
 jackson2-api:2.17.0-379.v02de8ec9f64c
-jacoco:3.3.7
 jakarta-activation-api:2.1.3-1
 jakarta-mail-api:2.1.3-1
 javadoc:280.v050b_5c849f69


### PR DESCRIPTION
This plugin is deprecated in favor of `coverage` as per https://plugins.jenkins.io/jacoco/

<img width="965" alt="Capture d’écran 2024-11-20 à 16 37 13" src="https://github.com/user-attachments/assets/135b22b1-c282-48cb-98e6-88b71fc2703b">
