### PR TITLE
feat(infra.ci) remove jenkins-design-language plugins as part of blueocean

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -67,7 +67,6 @@ javax-activation-api:1.2.0-7
 javax-mail-api:1.6.2-10
 jaxb:2.3.9-1
 jdk-tool:80.v8a_dee33ed6f0
-jenkins-design-language:1.27.16
 jersey2-api:2.44-151.v6df377fff741
 jira:3.13
 jjwt-api:0.11.5-112.ve82dfb_224b_a_d


### PR DESCRIPTION
as per https://github.com/jenkins-infra/docker-jenkins-infraci/pull/66#issuecomment-2492088816