### PR TITLE
fix(plugins): revert azure-vm-agents to 980.v4742455100fe

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -9,7 +9,7 @@ aws-java-sdk-minimal:1.12.772-474.v7f79a_2046a_fb_
 azure-container-agents:253.vd2f5cd5c5040
 azure-credentials:343.vd80f9c4859df
 azure-sdk:191.v53ec8913ee10
-azure-vm-agents:984.v3684c515c3d5
+azure-vm-agents:980.v4742455100fe
 basic-branch-build-strategies:190.v343a_ee70d920
 bootstrap5-api:5.3.3-1
 bouncycastle-api:2.30.1.78.1-248.ve27176eb_46cb_


### PR DESCRIPTION
since new version azure-vm-agents:984.v3684c515c3d5 seems to have bugs 
```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Unknown Source)
	at java.base/java.util.ImmutableCollections$List12.indexOf(Unknown Source)
	at java.base/java.util.ImmutableCollections$AbstractImmutableList.contains(Unknown Source)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate.createDeployment(AzureVMManagementServiceDelegate.java:735)
Caused: com.microsoft.azure.vmagent.exceptions.AzureCloudException
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.exceptions.AzureCloudException.create(AzureCloudException.java:54)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.exceptions.AzureCloudException.create(AzureCloudException.java:33)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate.createDeployment(AzureVMManagementServiceDelegate.java:771)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate.createDeployment(AzureVMManagementServiceDelegate.java:220)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMAgentTemplate.provisionAgents(AzureVMAgentTemplate.java:1359)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMCloud$1.call(AzureVMCloud.java:817)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMCloud$1.call(AzureVMCloud.java:813)
Caused: java.util.concurrent.ExecutionException
	at java.base/java.util.concurrent.FutureTask.report(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.get(Unknown Source)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMCloud$2.call(AzureVMCloud.java:848)
Caused: com.microsoft.azure.vmagent.exceptions.AzureCloudException
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.exceptions.AzureCloudException.create(AzureCloudException.java:54)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.exceptions.AzureCloudException.create(AzureCloudException.java:33)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMCloud$2.call(AzureVMCloud.java:851)
	at PluginClassLoader for azure-vm-agents//com.microsoft.azure.vmagent.AzureVMCloud$2.call(AzureVMCloud.java:837)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```