### PR TITLE
chore(Jenkinsfile_k8s): Remove automaticSemanticVersioning from script call

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,4 @@
 buildDockerAndPublishImage('jenkins-infraci', [
-    automaticSemanticVersioning: true,
     targetplatforms: 'linux/amd64,linux/arm64',
     nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
 ])


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/2778

`automaticSemanticVersioning` is set to true by default, we no longer need to set the parameter in the script call.