### PR TITLE
chore(Jenkinsfile_k8s) fail fast when get next version return empty or half-empty values

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,7 @@
 buildDockerAndPublishImage('jenkins-infraci', [
     targetplatforms: 'linux/arm64',
     publishToPrivateAzureRegistry: true,
-    nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
+    // The following command must return an exit code different than zero if jx-release-version or grep fail to find value. Hence the echo as last step.
+    // git gc ensures we don't run into https://github.com/jenkins-infra/docker-jenkins-lts/issues/1084
+    nextVersionCommand: 'git gc && semver="$(jx-release-version -next-version=semantic:strip-prerelease)" && prerelease="$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)" && echo "$semver"-"$prerelease"',
 ])


### PR DESCRIPTION
Twin of https://github.com/jenkins-infra/docker-jenkins-lts/pull/1085